### PR TITLE
Add UUID generation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ This server provides the following tools:
      - `payload`: Decoded JWT payload (object)
      - `signature`: JWT signature (string or null)
 
+9. **generate_uuid**
+   - Generate a UUID
+   - Inputs:
+     - `version` (string): The version of UUID to generate (`v4` or `v7`)
+   - Returns: UUID string
+
 ## License
 
 This project is licensed under the terms of the MIT open source license. Please refer to [MIT](./LICENSE) for the full terms.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ This server provides the following tools:
    - Returns: QR code image (data URL)
 
 8. **decode_jwt**
+
    - Decode a JWT token
    - Inputs:
      - `token` (string): JWT token string
@@ -97,10 +98,13 @@ This server provides the following tools:
      - `signature`: JWT signature (string or null)
 
 9. **generate_uuid**
-   - Generate a UUID
+
+   - Generate UUID v4 and v7
    - Inputs:
-     - `version` (string): The version of UUID to generate (`v4` or `v7`)
-   - Returns: UUID string
+     - (no parameters required)
+   - Returns: JSON object containing both v4 and v7 UUIDs
+     - `v4`: UUID v4 string
+     - `v7`: UUID v7 string
 
 ## License
 

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import * as color from "./operations/color.js";
 import * as datetime from "./operations/datetime.js";
 import * as qr from "./operations/qr.js";
 import { JWTDecodeOptions, decodeJWT } from "./operations/jwt.js";
+import { UUIDGenerateSchema, generateUUID } from "./operations/uuid.js";
 
 const server = new Server(
   {
@@ -68,6 +69,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "decode_jwt",
         description: "Decode a JWT token",
         inputSchema: zodToJsonSchema(JWTDecodeOptions),
+      },
+      {
+        name: "generate_uuid",
+        description: "Generate a UUID",
+        inputSchema: zodToJsonSchema(UUIDGenerateSchema),
       },
     ],
   };
@@ -134,6 +140,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const response = await decodeJWT(args);
         return {
           content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+        };
+      }
+      case "generate_uuid": {
+        const args = UUIDGenerateSchema.parse(request.params.arguments);
+        const response = await generateUUID(args);
+        return {
+          content: [{ type: "text", text: response }],
         };
       }
       default:

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ import { UUIDGenerateSchema, generateUUID } from "./operations/uuid.js";
 const server = new Server(
   {
     name: "web-development-toolbox-mcp-server",
-    version: "0.2.0",
+    version: "0.3.0",
   },
   {
     capabilities: {
@@ -72,7 +72,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "generate_uuid",
-        description: "Generate a UUID",
+        description: "Generate UUID v4 and v7",
         inputSchema: zodToJsonSchema(UUIDGenerateSchema),
       },
     ],
@@ -146,7 +146,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const args = UUIDGenerateSchema.parse(request.params.arguments);
         const response = await generateUUID(args);
         return {
-          content: [{ type: "text", text: response }],
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
         };
       }
       default:

--- a/operations/uuid.ts
+++ b/operations/uuid.ts
@@ -1,19 +1,13 @@
 import { z } from "zod";
 import { v4, v7 } from "uuid";
 
-const UUIDGenerateOptions = z.object({
-  version: z.enum(["v4", "v7"]).describe("The version of UUID to generate"),
-});
+const UUIDGenerateOptions = z.object({});
 
-const UUIDGenerateSchema = UUIDGenerateOptions;
+export const UUIDGenerateSchema = UUIDGenerateOptions;
 
 export async function generateUUID(params: z.infer<typeof UUIDGenerateSchema>) {
-  switch (params.version) {
-    case "v4":
-      return v4();
-    case "v7":
-      return v7();
-    default:
-      throw new Error(`Unsupported UUID version: ${params.version}`);
-  }
+  return {
+    v4: v4(),
+    v7: v7(),
+  };
 }

--- a/operations/uuid.ts
+++ b/operations/uuid.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { v4, v7 } from "uuid";
+
+const UUIDGenerateOptions = z.object({
+  version: z.enum(["v4", "v7"]).describe("The version of UUID to generate"),
+});
+
+const UUIDGenerateSchema = UUIDGenerateOptions;
+
+export async function generateUUID(params: z.infer<typeof UUIDGenerateSchema>) {
+  switch (params.version) {
+    case "v4":
+      return v4();
+    case "v7":
+      return v7();
+    default:
+      throw new Error(`Unsupported UUID version: ${params.version}`);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-development-toolbox-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-development-toolbox-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.7.0",
@@ -15,6 +15,7 @@
         "node-fetch": "^3.3.2",
         "qr-image": "^3.2.0",
         "universal-user-agent": "^7.0.2",
+        "uuid": "^11.1.0",
         "zod": "^3.23.0",
         "zod-to-json-schema": "^3.24.0"
       },
@@ -23,6 +24,7 @@
       },
       "devDependencies": {
         "@types/qr-image": "^3.2.9",
+        "@types/uuid": "^10.0.0",
         "shx": "^0.4.0",
         "typescript": "^5.6.3"
       }
@@ -114,6 +116,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -1744,6 +1753,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-development-toolbox-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "MCP Server for Web developers",
   "license": "MIT",
   "author": "noboru-i",
@@ -31,11 +31,13 @@
     "node-fetch": "^3.3.2",
     "qr-image": "^3.2.0",
     "universal-user-agent": "^7.0.2",
+    "uuid": "^11.1.0",
     "zod": "^3.23.0",
     "zod-to-json-schema": "^3.24.0"
   },
   "devDependencies": {
     "@types/qr-image": "^3.2.9",
+    "@types/uuid": "^10.0.0",
     "shx": "^0.4.0",
     "typescript": "^5.6.3"
   }


### PR DESCRIPTION
Fixes #2

Add functionality to generate UUIDs.

* **New File `operations/uuid.ts`**
  - Import `z` from `zod` and `v4`, `v7` from `uuid`.
  - Define `UUIDGenerateOptions` schema as empty.
  - Define `UUIDGenerateSchema` as `UUIDGenerateOptions`.
  - Export `generateUUID` function to generate UUID v4 and v7.

* **Update `index.ts`**
  - Import `UUIDGenerateSchema` and `generateUUID` from `operations/uuid.js`.
  - Add a new tool entry for `generate_uuid` in the `ListToolsRequestSchema` handler.
  - Add a new case for `generate_uuid` in the `CallToolRequestSchema` handler.
  - Parse arguments using `UUIDGenerateSchema` and call `generateUUID`.

* **Update `README.md`**
  - Add a new tool entry for `generate_uuid` in the Tools section.
  - Describe the inputs and outputs for `generate_uuid`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/noboru-i/web-development-toolbox/pull/9?shareId=51a2f04e-3b2d-41b3-98ce-763ff69fc0a1).