### PR TITLE
fix: Update GitHub Actions workflow dependency installation

### DIFF
--- a/.github/workflows/build-dxt.yml
+++ b/.github/workflows/build-dxt.yml
@@ -24,7 +24,8 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm install
+        working-directory: ./packages/web-development-toolbox-mcp
+        run: npm ci
 
       - name: Install DXT CLI
         run: npm install -g @anthropic-ai/dxt


### PR DESCRIPTION
## Summary
- GitHub Actions ワークフローの依存関係インストールを修正
- 正しいディレクトリ（packages/web-development-toolbox-mcp）から依存関係をインストール
- より信頼性の高いCI構築のためnpm installからnpm ciに変更

## Test plan
- [ ] GitHub Actionsワークフローが正常に実行されることを確認
- [ ] DXTパッケージビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)